### PR TITLE
Use --vimgrep as well as --no-heading

### DIFF
--- a/ripgrep.el
+++ b/ripgrep.el
@@ -172,7 +172,7 @@ This function is called from `compilation-filter-hook'."
                 (append (list ripgrep-executable)
                         ripgrep-arguments
                         args
-                        '("--vimgrep")
+                        '("--no-heading --vimgrep")
                         (list (shell-quote-argument regexp) ".")) " ")
      'ripgrep-search-mode)))
 

--- a/ripgrep.el
+++ b/ripgrep.el
@@ -172,7 +172,7 @@ This function is called from `compilation-filter-hook'."
                 (append (list ripgrep-executable)
                         ripgrep-arguments
                         args
-                        '("--no-heading")
+                        '("--vimgrep")
                         (list (shell-quote-argument regexp) ".")) " ")
      'ripgrep-search-mode)))
 


### PR DESCRIPTION
--no-heading leaves control chars in the output listing (ripgrep 0.2.1)