### PR TITLE
The -n option is needed for Windows.

### DIFF
--- a/ripgrep.el
+++ b/ripgrep.el
@@ -172,7 +172,7 @@ This function is called from `compilation-filter-hook'."
                 (append (list ripgrep-executable)
                         ripgrep-arguments
                         args
-                        '("--no-heading --vimgrep")
+                        '("--no-heading --vimgrep -n")
                         (list (shell-quote-argument regexp) ".")) " ")
      'ripgrep-search-mode)))
 


### PR DESCRIPTION
A Windows user told me that line numbers were not displayed without the -n option.
