### PR TITLE
projectile-ripgrep: Use rg's `--glob` flag to ignore files

### DIFF
--- a/projectile-ripgrep.el
+++ b/projectile-ripgrep.el
@@ -49,7 +49,7 @@
     (read-from-minibuffer "Ripgrep search for: " (thing-at-point 'symbol))))
   (ripgrep-regexp regexp
                   (projectile-project-root)
-                  (mapcar (lambda (val) (concat "--not-file-matches=" val))
+                  (mapcar (lambda (val) (concat "--glob !" val))
                           (append projectile-globally-ignored-files
                                   projectile-globally-ignored-directories))))
 


### PR DESCRIPTION
Use a negated glob to ignore projectile globally ignored files and
directories. The previous flag, `--not-file-matches` is not a valid
flag for ripgrep 0.2.9.

Fixes #10.