### PR TITLE
Remove duplicate Commentary section from ripgrep.el

### DIFF
--- a/ripgrep.el
+++ b/ripgrep.el
@@ -7,11 +7,6 @@
 ;; Keywords : ripgrep ack pt ag sift grep search
 ;; Homepage: https://github.com/nlamirault/ripgrep.el
 
-;;; Commentary:
-
-;; Please see README.md for documentation, or read it online at
-;; https://github.com/nlamirault/ripgrep.el
-
 ;;; License:
 
 ;; This program is free software; you can redistribute it and/or


### PR DESCRIPTION
The duplicate section was causing the helpful usage info to be ignored, such that the much-less-helpful "please see the README" comment was included on the MELPA package page and in the Emacs package list.

In general, you should document the package in the `Commentary` wherever possible, in the spirit of Emacs' self-documenting ideal. :-)