### PR TITLE
Make projectile-ripgrep behave like projectile-ag

### DIFF
--- a/projectile-ripgrep.el
+++ b/projectile-ripgrep.el
@@ -42,16 +42,27 @@
 (require 'ripgrep)
 
 ;;;###autoload
-(defun projectile-ripgrep (regexp)
-  "Run a Ripgrep search with `REGEXP' rooted at the current projectile project root."
+(defun projectile-ripgrep (search-term &optional arg)
+  "Run a Ripgrep search with `SEARCH-TERM' rooted at the current projectile project root.
+
+With an optional prefix argument `ARG' `SEARCH-TERM' is interpreted as a
+regular expression."
   (interactive
    (list
-    (read-from-minibuffer "Ripgrep search for: " (thing-at-point 'symbol))))
-  (ripgrep-regexp regexp
-                  (projectile-project-root)
-                  (mapcar (lambda (val) (concat "--glob !" val))
-                          (append projectile-globally-ignored-files
-                                  projectile-globally-ignored-directories))))
+    (read-from-minibuffer (projectile-prepend-project-name (format "Ripgrep %ssearch for: "
+                                                                   (if current-prefix-arg
+                                                                       "regexp "
+                                                                     "")))
+                          (projectile-symbol-or-selection-at-point))
+    current-prefix-arg))
+  (let ((args (mapcar (lambda (val) (concat "--glob !" val))
+                      (append projectile-globally-ignored-files
+                              projectile-globally-ignored-directories))))
+    (ripgrep-regexp search-term
+                    (projectile-project-root)
+                    (if current-prefix-arg
+                        args
+                      (cons "--fixed-strings" args)))))
 
 
 (provide 'projectile-ripgrep)


### PR DESCRIPTION
By default search for exact matches, with the prefix argument as a regular expression.
