### PR TITLE
Honour `case-fold-search' when search string not mixed case

### DIFF
--- a/ripgrep.el
+++ b/ripgrep.el
@@ -183,6 +183,9 @@ This function is called from `compilation-filter-hook'."
                         args
                         '("--no-heading --vimgrep -n")
                         (when ripgrep-highlight-search '("--color=always"))
+                        (when (and case-fold-search
+                                   (isearch-no-upper-case-p regexp t))
+                          '("--ignore-case"))
                         '("--")
                         (list (shell-quote-argument regexp) ".")) " ")
      'ripgrep-search-mode)))


### PR DESCRIPTION
Similar behaviour to the standard grep facilities in Emacs.