### PR TITLE
Allow regex searching non-interactively.

### DIFF
--- a/projectile-ripgrep.el
+++ b/projectile-ripgrep.el
@@ -60,7 +60,7 @@ regular expression."
                               projectile-globally-ignored-directories))))
     (ripgrep-regexp search-term
                     (projectile-project-root)
-                    (if current-prefix-arg
+                    (if arg
                         args
                       (cons "--fixed-strings" args)))))
 


### PR DESCRIPTION
The current implementation checks `current-prefix-arg` directly when determining whether to search for a regex, rather than using the local binding of `arg`, so `projectile-ripgrep` cannot be used non-interactively to search for a regex.