### PR TITLE
projectile-ripgrep: fix unescaped glob (#31)

### DIFF
--- a/projectile-ripgrep.el
+++ b/projectile-ripgrep.el
@@ -55,7 +55,7 @@ regular expression."
                                                                      "")))
                           (projectile-symbol-or-selection-at-point))
     current-prefix-arg))
-  (let ((args (mapcar (lambda (val) (concat "--glob !" val))
+  (let ((args (mapcar (lambda (val) (concat "--glob \\!" val))
                       (append (projectile-ignored-files-rel)
                               (projectile-ignored-directories-rel)))))
     (ripgrep-regexp search-term


### PR DESCRIPTION
The generated command used to look like:

```
rg --fixed-strings --glob !TAGS [..] -- <query> .
```

which caused an exit code 1.

When I copied and ran that command directly in bash (version 5.2.2), I got an error: `bash: !TAGS event not found`.

Due to histchar, bash is treating the !TAGS as a history event https://serverfault.com/questions/208265/what-is-bash-event-not-found

Fix the problem by escaping the exclamation mark. I verified that the exclusion works as intended when the exclamation is escaped.

The new command looks like:

```
rg --fixed-strings --glob \!TAGS [..] -- <query> .
```